### PR TITLE
Fixed arm geometry message timestamp

### DIFF
--- a/arduino/RUR099/RUR099.ino
+++ b/arduino/RUR099/RUR099.ino
@@ -409,8 +409,8 @@ void loop() {
 
             k.transform.rotation = tf::createQuaternionFromYaw(0);
 
-            broadcaster.sendTransform(k);
             k.header.stamp = nh.now();
+            broadcaster.sendTransform(k);
 
             // *** broadcast odom message ***
 


### PR DESCRIPTION
Launching rviz (either manually or from the navigation launch file) would spam the log with error messages relating to the arm geometry broadcast messages:

[ WARN] [1664852191.766332164]: TF_REPEATED_DATA ignoring data with redundant timestamp for frame arm at time 0.000000 according to authority unknown_publisher
Warning: TF_REPEATED_DATA ignoring data with redundant timestamp for frame arm at time 0.000000 according to authority unknown_publisher at line 278 in /home/sean/ros_catkin_ws/src/geometry2/tf2/src/buffer_core.cpp

This change adds the timestamp before the broadcast is sent to resolve this issue